### PR TITLE
Fix Tielur's 💔

### DIFF
--- a/lib/alice/handlers/tielurs_heart_rate.ex
+++ b/lib/alice/handlers/tielurs_heart_rate.ex
@@ -6,11 +6,10 @@ defmodule Alice.Handlers.TielursHeartRate do
   use Alice.Router
   use Timex
 
-  route ~r/(tielur|tielurs|tielur's) (heart|\:heart\:)/i,         :heart_rate
+  route ~r/(tielur|tielurs|tielur's) (heart|\:heart\:|[❤️💛💚💙💜❣️💕💓💗💖💘💝💟💔])/iu, :heart_rate
 
   def heart_rate(conn) do
-    conn
-    |> TielursHeartRate.measure
+    TielursHeartRate.measure
     |> List.first
     |> format_message
     |> reply(conn)


### PR DESCRIPTION
Fixes `heart_rate/1` so that it doesn't pass conn into `TielursHeartRate.measure`. This will default to 1. Also adds some emoji to the regex. Because emoji